### PR TITLE
feat: add toolchain identification system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,6 +128,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-x"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -319,6 +325,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "faccess"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -328,6 +344,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "find-msvc-tools"
@@ -769,6 +791,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
 name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1128,6 +1156,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
+name = "rustix"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+dependencies = [
+ "bitflags 2.10.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1214,10 +1255,13 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "argh",
+ "base-x",
  "cmd_lib",
  "pathdiff",
  "reqwest",
+ "tempfile",
  "tokio",
+ "toml",
  "tracing",
  "tracing-log",
  "tracing-subscriber",
@@ -1292,6 +1336,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -1393,6 +1446,19 @@ checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1517,6 +1583,45 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.9.11+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3afc9a848309fe1aaffaed6e1546a7a14de1f935dc9d89d32afd9a44bab7c46"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "tower"
@@ -2076,6 +2181,12 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,10 +6,13 @@ edition = "2024"
 [dependencies]
 anyhow = "1.0.100"
 argh = "0.1.13"
+base-x = "0.2.11"
 cmd_lib = "2.0.0"
 pathdiff = "0.2.3"
 reqwest = "0.13.1"
+tempfile = "3.24.0"
 tokio = { version = "1.49.0", features = ["fs", "macros", "rt"] }
+toml = "0.9.11"
 tracing = "0.1.44"
 tracing-log = "0.2.0"
 tracing-subscriber = "0.3.22"

--- a/src/rustup.rs
+++ b/src/rustup.rs
@@ -14,6 +14,10 @@ fn rustup_url(version: &str) -> String {
     )
 }
 
+pub fn manifest_url(channel: &str) -> String {
+    format!("https://static.rust-lang.org/dist/channel-rust-{channel}.toml")
+}
+
 pub async fn setup(dest: &Path) -> Result<()> {
     // Pin a pre-XDG rustup to simplify path config.
     let url = rustup_url("1.28.2");

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -1,0 +1,80 @@
+use std::{
+    borrow::ToOwned,
+    collections::BTreeSet,
+    fs,
+    hash::{DefaultHasher, Hash, Hasher},
+    path::Path,
+    sync::LazyLock,
+};
+
+use anyhow::{self, Context, Result};
+
+use crate::util::HashEncoder;
+
+static CHANNEL_MANIFEST_SUBPATH: LazyLock<&'static Path> =
+    LazyLock::new(|| Path::new("lib/rustlib/multirust-channel-manifest.toml"));
+
+static COMPONENTS_SUBPATH: LazyLock<&'static Path> =
+    LazyLock::new(|| Path::new("lib/rustlib/components"));
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct IdentifiableToolchain {
+    /// The value of `pkg.rust.version` in the channel manifest.
+    pub rust_ver: String,
+
+    /// The items in the `components` file.
+    // TODO: Investigate whether host targets need to be normalized,
+    // as well as whether `multirust-config.toml` should be used instead.
+    pub components: BTreeSet<String>,
+}
+
+impl IdentifiableToolchain {
+    pub fn new(toolchain: &Path) -> Result<Self> {
+        let manifest_path = toolchain.join(*CHANNEL_MANIFEST_SUBPATH);
+        let rust_ver = rust_ver_from_manifest(&manifest_path)?;
+
+        let components_path = toolchain.join(*COMPONENTS_SUBPATH);
+        let components = fs::read_to_string(components_path)?;
+        let components = components.lines().map(ToOwned::to_owned).collect();
+
+        Ok(Self {
+            rust_ver,
+            components,
+        })
+    }
+
+    pub fn id(&self) -> String {
+        let mut id = String::new();
+
+        let mut hasher = DefaultHasher::new();
+        self.rust_ver.hash(&mut hasher);
+        id.push_str(&HashEncoder::encode(hasher.finish()));
+
+        id.push('-');
+
+        hasher = DefaultHasher::new();
+        self.components.hash(&mut hasher);
+        id.push_str(&HashEncoder::encode(hasher.finish()));
+
+        id
+    }
+}
+
+pub fn rust_ver_from_manifest(manifest_path: &Path) -> Result<String> {
+    fn enter_table<'v>(table: &'v toml::Value, key: &str) -> Result<&'v toml::Value> {
+        table
+            .as_table()
+            .context("expecting a table")?
+            .get(key)
+            .with_context(|| format!("failed to find item with key '{key}'"))
+    }
+
+    let manifest = fs::read_to_string(manifest_path)
+        .with_context(|| format!("when reading manifest at {}", manifest_path.display()))?;
+    let manifest: toml::Value = toml::from_str(&manifest)?;
+    Ok(enter_table(&manifest, "pkg")
+        .and_then(|pkg| enter_table(pkg, "rust"))
+        .and_then(|rust| enter_table(rust, "version"))
+        .context("failed to get pkg.rust from channel manifest")?
+        .to_string())
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -5,7 +5,7 @@ use tokio::{fs::File, io::AsyncWriteExt};
 
 pub const BUILD_TARGET: &str = env!("TARGET");
 
-pub fn normalize_toolchain(toolchain: &str) -> Cow<'_, str> {
+pub fn qualify_with_target(toolchain: &str) -> Cow<'_, str> {
     let suffix = format!("-{BUILD_TARGET}");
     if toolchain.ends_with(&suffix) {
         return toolchain.into();
@@ -19,4 +19,24 @@ pub async fn download_file(url: &str, dest: &Path) -> Result<()> {
     let bytes = resp.bytes().await?;
     dest.write_all(&bytes).await?;
     Ok(())
+}
+
+pub struct HashEncoder;
+
+impl HashEncoder {
+    pub const ALPHABET: [u8; 32] = *b"0123456789abcdefhjkmnqprstuvwxyz";
+
+    pub fn encode(hash: u64) -> String {
+        base_x::encode(Self::ALPHABET.as_ref(), &hash.to_le_bytes())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hash_encode() {
+        assert_eq!(HashEncoder::encode(112_358_777), "7kxdk0s000000");
+    }
 }


### PR DESCRIPTION
The idea here is relatively simple, i.e. we should determine a UID that is:

- Universally applicable to all modifiable toolchains.
- Unique enough for each `(version, components)` tuple.
- Identical when the `(version, components)` tuple is identical.
- Can be easily determined both on-disk and pre-flight by only analyzing the channel manifest and the list of components to be installed.

```console
> cargo run -- id 1.92         # Locally-installed `1.92` at v1.92.0
tw95n4wjkbat-1f5m2qq9fjkdv

> cargo run -- id stable       # Locally-installed `stable` at v1.92.0
tw95n4wjkbat-1f5m2qq9fjkdv

> cargo run -- id-chan 1.92.0  # Fetched manifest from the `1.92.0` channel
tw95n4wjkbat-1f5m2qq9fjkdv
```